### PR TITLE
Fix: Correct JSX syntax error in BudgetSummary.tsx

### DIFF
--- a/client/src/components/BudgetSummary.tsx
+++ b/client/src/components/BudgetSummary.tsx
@@ -144,14 +144,16 @@ const BudgetSummary: React.FC = () => {
                 </Paper>
             )}
 
-            {/* Potential for adding charts here using Recharts or similar */} 
-            {/* <Box sx={{ mt: 4 }}>
+            {/* Potential for adding charts here using Recharts or similar */}
+            {/*
+            <Box sx={{ mt: 4 }}>
                 <Typography variant="h6" gutterBottom>กราฟสรุป (ตัวอย่าง)</Typography>
                 <Paper sx={{ p: 2 }}>
                     <Typography color="text.secondary">กราฟแสดงสัดส่วนรายจ่าย หรือแนวโน้มงบประมาณ...</Typography>
-                    {/* Chart component would go here */}
+                    // Chart component would go here
                 </Paper>
-            </Box> */}
+            </Box>
+            */}
         </Box>
     );
 };


### PR DESCRIPTION
The client-side build was failing with a "Syntax error: Expected corresponding JSX closing tag for 'Box'" in
client/src/components/BudgetSummary.tsx.

This was caused by an improperly commented-out JSX block. This commit adjusts the JSX comments to correctly deactivate the problematic code block, resolving the syntax error.